### PR TITLE
fix: convert Amazon Q CLI references to Kiro CLI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 CFM Tips - AWS Cost Optimization MCP Server Setup Script
 
 This script helps set up the CFM Tips AWS Cost Optimization MCP Server
-for use with Amazon Q CLI and other MCP-compatible clients.
+for use with Kiro CLI and other MCP-compatible clients.
 """
 
 import os
@@ -109,11 +109,11 @@ def create_mcp_config():
     print("\n⚙️  Creating MCP configuration...")
     
     current_dir = os.getcwd()
-    amazonq_dir = Path.home() / ".aws" / "amazonq"
-    config_file = amazonq_dir / "mcp.json"
+    kiro_dir = Path.home() / ".kiro" / "settings"
+    config_file = kiro_dir / "mcp.json"
     
-    # Create amazonq directory if it doesn't exist
-    amazonq_dir.mkdir(parents=True, exist_ok=True)
+    # Create kiro directory if it doesn't exist
+    kiro_dir.mkdir(parents=True, exist_ok=True)
     
     # Load existing config or create new one
     existing_config = {}
@@ -235,9 +235,9 @@ def show_usage_instructions(config_file):
     print("=" * 60)
     
     print("\n🚀 Quick Start:")
-    print(f"   q chat ")
+    print("   kiro-cli chat")
     
-    print("\n💬 Example commands in Amazon Q:")
+    print("\n💬 Example commands in Kiro:")
     examples = [
         "Run comprehensive cost analysis for us-east-1",
         "Find unused EBS volumes costing money",
@@ -308,7 +308,7 @@ def main():
     if aws_ok and test_ok:
         show_usage_instructions(config_file)
         print("\n🎯 Ready to use! Start with:")
-        print(f"   q chat ")
+        print("   kiro-cli chat")
     else:
         print("\n⚠️  Setup completed with warnings. Please address the issues above.")
         if not aws_ok:


### PR DESCRIPTION
## What does this PR do?
Converts the CFM Tips MCP server setup from Amazon Q CLI to Kiro CLI compatibility.

## Why is this change needed?
Amazon Q CLI has been deprecated and replaced by Kiro CLI. The current setup script creates configuration files in the wrong location (`~/.aws/amazonq/`) and references outdated commands, preventing users from properly configuring the MCP server with Kiro CLI.

## Changes Made
- **Directory path**: Changed from `~/.aws/amazonq/mcp.json` to `~/.kiro/settings/mcp.json`
- **Command references**: Updated from `q chat` to `kiro-cli chat`
- **Documentation**: Changed "Amazon Q CLI" references to "Kiro CLI"
- **User instructions**: Updated example commands to use Kiro CLI

## Testing
- ✅ Local testing confirms setup script now creates config in correct Kiro location
- ✅ All integration tests pass (`python3 test_runbooks.py`)
- ✅ MCP server starts correctly with new configuration
- ✅ Maintains backward compatibility for MCP configuration format

## Breaking Changes
None. This is purely a configuration path and documentation update.

## Files Modified
- `setup.py` - Updated paths, commands, and documentation references

## How to Test
1. Run `python3 setup.py`
2. Verify config is created at `~/.kiro/settings/mcp.json`
3. Confirm output shows "kiro-cli chat" instead of "q chat"
4. Test MCP server functionality with Kiro CLI

Fixes the setup compatibility issue with Kiro CLI migration.